### PR TITLE
Add sign up page and log in page with minimal styling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Capstone Project Plan
-https://docs.google.com/document/d/1v0hlvbYmcrLQPKlnLxoS0snrZzQ52PWFToij3ySNQPs/edit?usp=sharing
+# <App Cine  Plus>
+
+**Deployed site**: <add a link to your deployment here, if you create one>
+
+## Overview
+<Add a quick description of your app here>
+
+## Links
+**Project Plan**: https://docs.google.com/document/d/1v0hlvbYmcrLQPKlnLxoS0snrZzQ52PWFToij3ySNQPs/edit?tab=t.0#heading=h.6b6nbvhbbspp
+
+**Wireframes**: [here]<add a link to wire frames>
+<img src="OR_INSERT_INLINE_YOUR_WIREFRAME_IMAGE_URL" width=600>
+
+<add any other links here as you work on your project>
+
+## Demo Video
+[TBD](<insert link in Week 9!>)

--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Cine+</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1613,6 +1614,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2484,6 +2494,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2549,6 +2597,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,4 @@
+
 #root {
   max-width: 1280px;
   margin: 0 auto;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,35 +1,18 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import {useState} from "react";
+import {Routes, Route} from  "react-router-dom"
+import LogIn from "./components/LogIn";
+import Home from "./components/Home";
+import "./App.css";
+import SignUp from "./components/SignUp";
 
 function App() {
-  const [count, setCount] = useState(0)
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  <Routes>
+      <Route path="/signup" element={<SignUp/>}/>
+      <Route path="/login" element={<LogIn/>}/>
+    </Routes>
+  );
 }
 
-export default App
+export default App;

--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import LogIn from "./LogIn";
+import SignUp from "./SignUp";
+
+const Home = () => {
+ return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default Home;

--- a/client/src/components/LogIn.css
+++ b/client/src/components/LogIn.css
@@ -1,0 +1,34 @@
+/* Login css styles */
+/* TODOS: */
+/* PLACE THE LINEAR GRADIENTBACKGROUND FOR THE LOGIN FORM*/
+
+.login-form {
+  max-width: 450px;
+  padding: 50px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  color: white;
+}
+
+.login-form h1 {
+  text-align: center;
+  color: white;
+}
+
+.login-form input {
+  padding: 12px;
+  border: 1px solid white;
+  background: transparent;
+  color: white;
+  font-size: 16px;
+}
+
+.login-form button {
+  padding: 12px;
+  background-color: #706d6d;
+  color: white;
+  cursor: pointer;
+  border-radius: 4px;
+}

--- a/client/src/components/LogIn.jsx
+++ b/client/src/components/LogIn.jsx
@@ -1,0 +1,57 @@
+import React, {useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {Link} from "react-router-dom";
+import "./LogIn.css";
+
+const LogIn = () => {
+  const [formData, setFormData] = useState({username: "", password: ""});
+  const navigate = useNavigate();
+
+  const handleChange = (event) => {
+    const {name, value} = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    console.log("TODO: This yet to be handled in the backend");
+    navigate("/");
+  };
+
+  return (
+    <div className="log-in">
+      <h1>PARTY WATCH</h1>
+      <form onSubmit={handleSubmit} className="login-form">
+        <input
+          type="text"
+          name="username"
+          placeholder="Email"
+          value={formData.username}
+          onChange={handleChange}
+          required
+        />
+
+        <input
+          type="password"
+          name="password"
+          placeholder="Password"
+          value={formData.password}
+          j
+          onChange={handleChange}
+          required
+        />
+
+        <button type="submit">Log In</button>
+      </form>
+      <p>
+        Don't have an account?
+        <Link to="/signup"> Sign Up </Link>
+      </p>
+    </div>
+  );
+};
+
+export default LogIn;

--- a/client/src/components/SignUp.css
+++ b/client/src/components/SignUp.css
@@ -1,0 +1,47 @@
+.sign-up{
+    display: flex;
+    color: white;
+}
+
+.signup-logo{
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.signup-right{
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.signup h2{
+    font-size: 32px;
+    margin-bottom: 4px;
+}
+
+.signup-form{
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.signup-form input {
+  padding: 12px;
+  border: 1px solid white;
+  background: transparent;
+  color: white;
+  font-size: 16px;
+}
+
+
+
+.signup-form button {
+  padding: 12px;
+  background-color: #706d6d;
+  color: white;
+  cursor: pointer;
+  border-radius: 4px;
+}

--- a/client/src/components/SignUp.jsx
+++ b/client/src/components/SignUp.jsx
@@ -1,0 +1,72 @@
+import {useState} from "react";
+import {Link} from "react-router-dom";
+import './SignUp.css'
+
+const SignUp = () => {
+  const [formData, setFormData] = useState({username: "", password: ""});
+  const [message, setMessage] = useState("");
+
+  // Handle input changes
+  const handleChange = (event) => {
+    const {name, value} = event.target;
+
+    setFormData((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  // Handle form submission
+  const handleSubmit = async (event) => {
+    event.preventDefault(); // Prevents page refresh
+    console.log("User Input:", formData); // Logs user input
+    console.log("TODO: handle sign up in the backend");
+  };
+
+  return (
+    <div className="sign-up">
+      <div className="signup-logo">
+        <p>here we will insert a image that presents my app.</p>
+      </div>
+
+    <div className="signup-right">
+ <div className="signup-form">
+    <h2>PARTY WATCH </h2>
+        <form className="signup-form" onSubmit={handleSubmit}>
+          <label htmlFor="username">Username</label>
+          <input
+            type="text"
+            id="username"
+            name="username"
+            value={formData.username}
+            onChange={handleChange}
+          />
+          <label htmlFor="password">Password</label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+          />
+          <div className="form-buttons">
+            <button type="submit">Sign Up</button>
+          </div>
+          {message && (
+            <div className={`message ${message.type}`}>{message.text}</div>
+          )}
+        </form>
+      </div>
+      <div className="divider">OR</div>
+
+      <p>
+        Already have an account?
+        <Link to="/login"> Login </Link>
+      </p>
+    </div>
+    </div>
+     
+  );
+};
+
+export default SignUp;

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useState, useContext } from 'react';
+
+const UserContext = createContext();
+
+export const UserProvider = ({ children }) => {
+    const [user, setUser] = useState(null);
+
+    return (
+        <UserContext.Provider value={{ user, setUser }}>
+            {children}
+        </UserContext.Provider>
+    );
+};
+
+export const useUser = () => useContext(UserContext);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -56,8 +56,7 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    /* deleted because it was overiding my original styles, if this causes problems, check later */
   }
   a:hover {
     color: #747bff;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,10 +1,11 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter} from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
+ <BrowserRouter>
     <App />
-  </StrictMode>,
+  </BrowserRouter>
+
 )

--- a/client/src/pages/LogInScreen.jsx
+++ b/client/src/pages/LogInScreen.jsx
@@ -1,0 +1,9 @@
+import LogIn from "../components/LogIn";
+const LogInScreen = () => {
+
+return (
+   <LogIn></LogIn>
+)
+};
+
+export default LogInScreen;

--- a/client/src/pages/SignUpScreen.jsx
+++ b/client/src/pages/SignUpScreen.jsx
@@ -1,0 +1,9 @@
+import SignUp from "../components/SignUp";
+const SignUpScreen = () => {
+
+return (
+   <SignUp></SignUp>
+)
+};
+
+export default SignUpScreen;


### PR DESCRIPTION
### **Description**
This pull request implements bare bones UI for log in and sign up pages.
-  Implements forms for sign up and log in (does not handle submit with the backend yet)
- Sets up routing links between the log in page and sign up page 
- Updates readme to the appropriate template. 
In future PRs:
- Polish styling as it appears in the Figma log in and sign up pages layout
- Handle the routes in the backend for sign up and log in   
### ****Milestones****

- This PR contributes directly to the signing in and logging in milestone/user story

###****Resources****
 My resources include the Codepath lab on authentication:
[https://github.com/codepath/adopt-a-pet-authentication-exemplar/tree/main/client/src/components](url)
### ****Test Plan****

![image](https://github.com/user-attachments/assets/268142f1-a502-4957-82f8-26bf79c8309b)

![image](https://github.com/user-attachments/assets/4b21dc7a-d088-4c4e-9960-afb3356852db)

I made sure the forms update on handlechagne. I also made sure on submit logs what I wrote to the console for now (console logs will be replaced with calls to the backend logic).
