### PR TITLE
Implement backend endpoints to handle comments and likes in the feed.

### DIFF
--- a/server/Routes/comment.js
+++ b/server/Routes/comment.js
@@ -1,0 +1,53 @@
+const express = require("express");
+const router = express.Router();
+const {addComment, getComments} = require("../database/feedUtils");
+
+router.post("/:watchedId", async (req, res) => {
+  if (!req.session.userId) {
+    return res
+      .status(401)
+      .json({error: "authentication required. Log in first"});
+  }
+
+  try {
+    const userId = req.session.userId;
+    const watchedId = parseInt(req.params.watchedId);
+    const {text} = req.body;
+
+    if (!text || text.trim().length === 0) {
+      return res.status(400).json({error: "comment text is required"});
+    }
+
+    const result = await addComment(userId, watchedId, text.trim());
+
+    if (result.success) {
+      res.status(201).json({
+        success: true,
+        message: "comment addded",
+        comment: result.comment,
+      });
+    } else {
+      res.status(500).json({error: "failed to add comment"});
+    }
+  } catch (error) {
+    console.log("error adding comment", error);
+    res.status(500).json({error: "failed to add comment"});
+  }
+});
+
+router.get("/:watchedId", async (req, res) => {
+  try {
+    const watchedId = parseInt(req.params.watchedId);
+    const comments = await getComments(watchedId);
+
+    res.json({
+      success: true,
+      comments: comments,
+      count: comments.length,
+    });
+  } catch (error) {
+    console.log("error getting comments", error);
+    res.status(500).json({error: "failed to get comment"});
+  }
+});
+module.exports = router;

--- a/server/Routes/like.js
+++ b/server/Routes/like.js
@@ -1,0 +1,112 @@
+const express = require("express");
+const router = express.Router();
+const {
+  addLike,
+  removeLike,
+  getLikesCount,
+  hasUserLiked,
+} = require("../database/feedUtils");
+
+router.post("/:watchedId", async (req, res) => {
+  if (!req.session.userId) {
+    return res
+      .status(401)
+      .json({error: "authentication required. Log in first"});
+  }
+
+  try {
+    const userId = req.session.userId;
+    const watchedId = parseInt(req.params.watchedId);
+
+    const alreadyLiked = await hasUserLiked(userId, watchedId);
+
+    if (alreadyLiked) {
+      return res.status(400).json({
+        error: "you have already liked this post",
+        alreadyLiked: true,
+      });
+    }
+    const result = await addLike(userId, watchedId);
+    if (result.success) {
+      const likes = await getLikesCount(watchedId);
+      res.json({
+        success: true,
+        message: "posted like successfully",
+        likeCount: likes,
+      });
+    } else {
+      res.status(500).json({error: "failed to like post"});
+    }
+  } catch (error) {
+    console.log("Error liking post", error);
+    res.status(500).json({error: "failed to like post"});
+  }
+});
+
+router.delete("/:watchedId", async (req, res) => {
+  if (!req.session.userId) {
+    return res
+      .status(401)
+      .json({error: "authentication required. Log in first"});
+  }
+
+  try {
+    const userId = req.session.userId;
+    const watchedId = parseInt(req.params.watchedId);
+
+    const result = await removeLike(userId, watchedId);
+
+    if (result.success) {
+      const likes = await getLikesCount(watchedId);
+      res.json({
+        success: true,
+        message: "like removed successfully",
+        likeCount: likes,
+      });
+    } else {
+      res.status(500).json({error: "failed to remove like"});
+    }
+  } catch (error) {
+    console.log("error removing like", error);
+    res.status(500).json({error: "failed to remove like"});
+  }
+});
+
+router.get("/:watchedId/status", async (req, res) => {
+  if (!req.session.userId) {
+    return res
+      .status(401)
+      .json({error: "authentication required. Log in first"});
+  }
+
+  try {
+    const userId = req.session.userId;
+    const watchedId = parseInt(req.params.watchedId);
+
+    const userLiked = await hasUserLiked(userId, watchedId);
+
+    res.json({
+      success: true,
+      userLiked: userLiked,
+    });
+  } catch (error) {
+    console.log("error checking like status", error);
+    res.status(500).json({error: "failed to check like status"});
+  }
+});
+
+router.get("/:watchedId/count", async (req, res) => {
+  try {
+    const watchedId = parseInt(req.params.watchedId);
+    const likesCount = await getLikesCount(watchedId);
+    res.json({
+      success: true,
+      likesCount: likesCount,
+    });
+  } catch (error) {
+    console.log("error getting lkes count", error);
+    res.status(500).json({error: "failed to get like count "});
+  }
+});
+
+module.exports = router;

--- a/server/app.js
+++ b/server/app.js
@@ -54,9 +54,14 @@ app.use("/users", users);
 const follow = require("./Routes/follow.js");
 app.use("/follow-requests", follow);
 
-
 const feed = require("./Routes/feed.js");
 app.use("/feed", feed);
+
+const likes = require("./Routes/like.js");
+app.use("/like", likes);
+
+const comment = require("./Routes/comment.js");
+app.use("/comment", comment);
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/server/database/feedUtils.js
+++ b/server/database/feedUtils.js
@@ -4,13 +4,26 @@ async function getFeed(userId, page, limit) {
   const session = getSession();
 
   try {
-    console.log("heyyy heyyy ");
-
     const offset = parseInt(page - 1) * limit;
     const query = `
   MATCH (currentUser:User {id: $userId})-[:FOLLOWS]->(friend:User)-[w:WATCHED]->(content)
   WHERE content:Movie OR content:TVShow
   MATCH (friend)-[:HAS_PROFILE]->(friendProfile:Profile)
+
+  OPTIONAL MATCH ()-[like:LIKED]->(rel)
+  WHERE id(rel) = id(w)
+  WITH currentUser, friend, friendProfile, w, content, count(like) as likesCount
+
+  OPTIONAL MATCH ()-[comment:COMMENTED]->(rel)
+  WHERE id(rel) = id(w)
+  WITH currentUser, friend, friendProfile, w, content, likesCount, count(comment) as commentsCount
+
+
+  OPTIONAL MATCH (currentUser)-[userLike: LIKED]->(rel)
+  WHERE id(rel) = id(w)
+  WITH currentUser, friend, friendProfile, w, content, likesCount, commentsCount,
+  userLike is NOT NULL as userLiked
+
   RETURN
     friend.username AS friendUsername,
     friend.id AS friendId,
@@ -21,7 +34,11 @@ async function getFeed(userId, page, limit) {
     content.title AS contentTitle,
     content.posterPath AS contentPoster,
     content.overview AS contentOverview,
-    labels(content)[0] AS contentType
+    labels(content)[0] AS contentType,
+    likesCount,
+    commentsCount,
+    userLiked,
+    id(w) as watchedId
   ORDER BY w.watchedAt DESC
   SKIP $offset
   LIMIT $limit
@@ -51,6 +68,11 @@ async function getFeed(userId, page, limit) {
         review: record.get("review"),
         watchedAt: record.get("watchedAt"),
       },
+      interactions: {
+        likesCount: record.get("likesCount").toNumber(),
+        commentCount: record.get("commentsCount").toNumber(),
+        userLiked: record.get("userLiked"),
+      },
     }));
 
     const hasNextPage = feedItems.length === limit;
@@ -67,6 +89,154 @@ async function getFeed(userId, page, limit) {
   }
 }
 
+async function addLike(userId, watchedId) {
+  const session = getSession();
+
+  try {
+    await session.run(
+      `
+      MATCH (user: User {id: $userId})
+      MATCH (w) WHERE id(w) = $watchedId
+      MERGE (user)-[:LIKED {createdAt: datetime()}]->(w)
+      `,
+      {userId, watchedId: neo4j.int(watchedId)}
+    );
+    return {
+      success: true,
+    };
+  } finally {
+    await session.close();
+  }
+}
+
+async function removeLike(userId, watchedId) {
+  const session = getSession();
+
+  try {
+    await session.run(
+      `
+      MATCH (user: User {id: $userId})-[like: LIKED]->(w)
+      WHERE id(w) = $watchedId
+      DELETE like
+      `,
+      {userId, watchedId: neo4j.int(watchedId)}
+    );
+
+    return {
+      success: true,
+    };
+  } finally {
+    await session.close();
+  }
+}
+
+async function addComment(userId, watchedId, commentText) {
+  const session = getSession();
+  try {
+    const result = await session.run(
+      `
+     MATCH (user:User {id: $userId})
+     MATCH (w) WHERE id(w) = $watchedId
+    MATCH (user)-[:HAS_PROFILE]->(profile)
+    
+    CREATE (user)-[:COMMENTED {text: $commentText, createdAt: datetime()}]->(w)
+  
+    RETURN 
+    user.id as userId,
+    user.username as username,
+    profile.profilePicture as profilePicture
+      `,
+      {userId, watchedId: neo4j.int(watchedId), commentText}
+    );
+    const record = result.records[0];
+    return {
+      success: true,
+      comment: {
+        userId: record.get("userId"),
+        username: record.get("username"),
+        profilePicture: record.get("profilePicture"),
+        text: commentText,
+        createdAt: new Date().toISOString(),
+      },
+    };
+  } finally {
+    await session.close();
+  }
+}
+
+async function getComments(watchedId) {
+  const session = getSession();
+  try {
+    const result = await session.run(
+      `
+      MATCH (w) WHERE id(w) = $watchedId
+      MATCH (user)-[comment: COMMENTED]-> (w)
+      MATCH (user)-[:HAS_PROFILE]->(profile)
+
+      RETURN 
+      user.id as userId,
+      user.name as username,
+      profile.profilePicture as profilePicture,
+      comment.text as text,
+      comment.createdAt as createdAt
+      ORDER BY comment.createdAt ASC
+      `,
+      {watchedId: neo4j.int(watchedId)}
+    );
+
+    return result.records.map((record) => ({
+      userId: record.get("userId"),
+      username: record.get("username"),
+      profilePicture: record.get("profilePicture"),
+      text: record.get("text"),
+      createdAt: record.get("createdAt"),
+    }));
+  } finally {
+    await session.close();
+  }
+}
+
+async function getLikesCount(watchedId) {
+  const session = getSession();
+  try {
+    const result = await session.run(
+      `
+      MATCH (w) WHERE id(w) = $watchedId
+      OPTIONAL MATCH (w)<-[:LIKED]-(user)
+      RETURN count(user) as likesCount
+      `,
+      {watchedId: neo4j.int(watchedId)}
+    );
+
+    return result.records[0].get("likesCount").toNumber();
+  } finally {
+    await session.close();
+  }
+}
+
+async function hasUserLiked(userId, watchedId) {
+  const session = getSession();
+  try {
+    const result = await session.run(
+      `
+      MATCH (user: User {id: $userId})
+      MATCH (w) WHERE id(w) = $watchedId
+      RETURN exists((user)-[:LIKED]->(w)) as hasLiked
+      `,
+      {userId, watchedId: neo4j.int(watchedId)}
+    );
+
+    return result.records[0].get("hasLiked");
+  } finally {
+    await session.close();
+  }
+}
 module.exports = {
   getFeed,
+  addLike,
+  removeLike,
+  hasUserLiked,
+  getLikesCount,
+  addComment,
+  getComments,
 };


### PR DESCRIPTION
## Description

<what this pull request is doing>
This pull request includes:

- implementation of backend endpoints for both likes and comments in the feed. 

Relevant edited and added files: 

- server/Routes/comment.js (route for comment endpodints)

- server/Routes/like.js (route for like endpoints)

- server/database/feedUtils.js (database helper functions for adding comment, getting comments, adding and unadding like)

- I have edited the get feed helper function to include comment count and like count.  

In future pull requests: 

- I plan to integrate comments and likes with the frontend. 

## Milestones
User story: As a TV show fanatic, I want to be able to view my friends' watchlists and see what they've been watching




## Resources
GEMINI GOOGLE RESPONSE to a type mismatch error in neo4j. 
```
The error message "Neo4j invalid input relationship for (w). expected to be a node but was a relationship" indicates a syntax issue in your Cypher query. This typically arises when you try to use a relationship in a context where a node is expected, or vice versa. 
Here's a breakdown of why this happens and how to fix it:
Nodes vs. Relationships: Remember that in Neo4j's property graph model, nodes represent entities (like a person or a movie), and relationships represent connections between nodes (like ACTED_IN or FRIEND_OF).
Cypher Syntax for Nodes and Relationships:
Nodes are represented by parentheses: (node_variable:Label {property: value}).
Relationships are represented by square brackets, often with arrows indicating direction: (start_node)-[:RELATIONSHIP_TYPE {property: value}]->(end_node).
Common Mistakes Leading to the Error:
Treating a relationship variable as a node variable: For example, if you have a relationship variable r, but your query attempts to use it as if it were a node, you'll encounter this error.
Incorrectly mixing node and relationship patterns: This can occur in MATCH or CREATE clauses where you might try to assign properties to a relationship variable as if it were a node, or attempt to define a relationship without a proper start and end node. 

```
## Test Plan

<img width="1315" height="874" alt="Screenshot 2025-07-20 at 11 13 34 AM" src="https://github.com/user-attachments/assets/7f473247-cd8b-42ce-a8be-05dd9865d615" />

<img width="1178" height="645" alt="Screenshot 2025-07-20 at 11 12 55 AM" src="https://github.com/user-attachments/assets/d7588463-d03e-4afe-8836-2f920147a04a" />

<img width="1209" height="753" alt="Screenshot 2025-07-20 at 11 13 42 AM" src="https://github.com/user-attachments/assets/b9638e44-ea47-4058-879f-7903d8098da8" />


<img width="1436" height="830" alt="Screenshot 2025-07-20 at 11 14 35 AM" src="https://github.com/user-attachments/assets/40ea1b98-2598-408b-a568-cd6f5204b2e3" />


<img width="1338" height="803" alt="Screenshot 2025-07-20 at 11 15 07 AM" src="https://github.com/user-attachments/assets/5ab49e52-3cb1-443b-b877-65ea782fc027" />

<img width="1130" height="920" alt="Screenshot 2025-07-20 at 11 36 20 AM" src="https://github.com/user-attachments/assets/bb2712b3-fad9-42cb-b2b6-acec175d1409" />

<img width="1334" height="885" alt="Screenshot 2025-07-20 at 12 11 53 PM" src="https://github.com/user-attachments/assets/5de80790-2f46-46d3-8d2e-79368cc1536a" />

<img width="1401" height="856" alt="Screenshot 2025-07-20 at 2 08 08 PM" src="https://github.com/user-attachments/assets/3dcb7ac7-e68a-40b7-ae7c-02668af53673" />

