### PR TITLE
Friend Request TC iterations

### DIFF
--- a/client/src/api/FollowApi.js
+++ b/client/src/api/FollowApi.js
@@ -2,6 +2,8 @@ const BASE_URL = "http://localhost:3000";
 
 export const followUser = async (userId) => {
   try {
+    console.log("supp");
+
     const response = await fetch(
       `${BASE_URL}/follow-requests/follow/${userId}`,
       {
@@ -9,7 +11,7 @@ export const followUser = async (userId) => {
         credentials: "include",
       }
     );
-
+    console.log("hi", response);
     const data = await response.json();
     if (response.ok) {
       return {
@@ -284,5 +286,38 @@ export const getRecs = async () => {
       success: false,
       message: "Exception occured in request",
     };
+  }
+};
+
+export const checkFriendOfFriendsAcess = async (userId) => {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/follow-requests/friend-of-friends/${userId}`,
+      {
+        credentials: "include",
+      }
+    );
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log("error checking friend of friends access", error);
+  }
+};
+
+export const cancelFollowRequest = async (userId) => {
+  console.log("helloooo");
+  try {
+    const response = await fetch(
+      `${BASE_URL}/follow-requests/cancel-request/${userId}`,
+      {
+        method: "DELETE",
+        credentials: "include",
+      }
+    );
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log("error canceling follow request", error);
   }
 };

--- a/client/src/api/MediaApiV2.js
+++ b/client/src/api/MediaApiV2.js
@@ -102,7 +102,6 @@ export async function getRandomShows() {
       );
 
       shows.push(...pageShows);
-      console.log("shows", shows);
     } catch (error) {
       console.error("Error fetching page:", error);
     }

--- a/client/src/api/ProfileApi.js
+++ b/client/src/api/ProfileApi.js
@@ -37,7 +37,7 @@ export const createUserProfile = async (userId, profileData) => {
       credentials: "include",
       body: JSON.stringify({
         bio: profileData.bio,
-        isPublic: profileData.isPublic,
+        privateLevel: profileData.privateLevel,
         profilePicture: profileData.profilePicture,
         favoriteGenres: profileData.favoriteGenres,
       }),
@@ -75,7 +75,7 @@ export const updateUserProfile = async (userId, profileData) => {
       credentials: "include",
       body: JSON.stringify({
         bio: profileData.bio,
-        isPublic: profileData.isPublic,
+        privacyLevel: profileData.privacyLevel,
         profilePicture: profileData.profilePicture,
         favoriteGenres: profileData.favoriteGenres,
       }),
@@ -131,17 +131,15 @@ export const userHasProfile = async (userId) => {
   }
 };
 
-export const updateProfilePrivacy = async (userId, isPublic) => {
+export const updateProfilePrivacy = async (userId, privacyLevel) => {
   try {
-    console.log("guyss", userId);
-    console.log("guyss2", isPublic);
     const response = await fetch(`${BASE_URL}/profile/${userId}/privacy`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
       },
       credentials: "include",
-      body: JSON.stringify({isPublic}),
+      body: JSON.stringify(privacyLevel),
     });
 
     const data = await response.json();

--- a/client/src/components/Settings/Settings.css
+++ b/client/src/components/Settings/Settings.css
@@ -1,0 +1,5 @@
+.privacy-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/client/src/components/Settings/Settings.jsx
+++ b/client/src/components/Settings/Settings.jsx
@@ -1,13 +1,31 @@
 import {useState, useEffect} from "react";
 import {getUserProfile, updateProfilePrivacy} from "../../api/ProfileApi";
 import {useUser} from "../../context/UserContext";
-
+import "./Settings.css";
 function Settings() {
   const {user} = useUser();
-  const [isPublic, setIsPublic] = useState(true);
+  const [privacyLevel, setPrivacyLevel] = useState("public");
   const [loading, setLoading] = useState(false);
   const [updating, setUpdating] = useState(false);
 
+  const privacyOptions = [
+    {
+      value: "friends_only",
+      label: "Private",
+      description: "Only your friends can see your profile and posts",
+    },
+    {
+      value: "friends_of_friends",
+      label: "Friends of Friends",
+      description:
+        "Your friends and and their friends can see your profile and posts",
+    },
+    {
+      value: "public",
+      label: "Public",
+      description: "Everyone can see your profile and posts",
+    },
+  ];
   useEffect(() => {
     fetchPrivacySettings();
   }, [user]);
@@ -21,7 +39,7 @@ function Settings() {
     try {
       const result = await getUserProfile(user.id);
       if (result.success) {
-        setIsPublic(result.profile.isPublic);
+        setPrivacyLevel(result.profile.privacyLevel);
       }
     } catch (error) {
       console.log("failed to fetch privacy settings", error);
@@ -37,9 +55,11 @@ function Settings() {
 
     setUpdating(true);
     try {
-      const result = await updateProfilePrivacy(user.id, newSetting);
+      const result = await updateProfilePrivacy(user.id, {
+        privacyLevel: newSetting,
+      });
       if (result.success) {
-        setIsPublic(newSetting);
+        setPrivacyLevel(newSetting);
       }
     } catch (error) {
       console.log("error updating privacy", error);
@@ -59,26 +79,32 @@ function Settings() {
   return (
     <div>
       <h2>Settings</h2>
+      <h3>Visibility</h3>
 
       <div className="privacy">
-        <h3>Privacy Settings</h3>
-        <label>
-          <input
-            type="checkbox"
-            checked={isPublic}
-            onChange={(e) => handlePrivacyChange(e.target.checked)}
-            disabled={updating}
-          ></input>
-          Make my profile public
-        </label>
-
+x        {privacyOptions.map((option) => (
+          <label key={option.value} className="privacy-label">
+            <div className="privacy-option">
+              <input
+                type="radio"
+                name="privacy"
+                value={option.value}
+                checked={privacyLevel === option.value}
+                onChange={(e) => handlePrivacyChange(e.target.value)}
+                disabled={updating}
+              ></input>
+            </div>
+            <p>{option.label}</p>
+          </label>
+        ))}{" "}
         <p>
-          {isPublic
-            ? "Your profile is now public. Others can see your posts and follow you"
-            : "Your profile is now private. Others need to request to see your content"}
+          currently selected:
+          {
+            privacyOptions.find((option) => option.value === privacyLevel)
+              ?.description
+          }
         </p>
         {updating && <p>updating...</p>}
-        
       </div>
     </div>
   );

--- a/client/src/components/auth/LogIn.jsx
+++ b/client/src/components/auth/LogIn.jsx
@@ -35,7 +35,7 @@ const LogIn = () => {
           if (!profile.hasProfile) {
             await createUserProfile(result.user.id, {
               bio: null,
-              isPublic: true,
+              privacyLevel: "public",
               profilePicture: null,
               favoriteGenres: null,
             });

--- a/client/src/components/feed/Feed.jsx
+++ b/client/src/components/feed/Feed.jsx
@@ -15,14 +15,9 @@ function Feed() {
     fetchInitialFeed,
     loadMoreItems,
   } = useFeed();
-  console.log("feedItems", feedItems);
-  console.log("filtered", filteredFeedItems);
-  console.log("feed items length", feedItems.length);
-  console.log("filtered items lenght", filteredFeedItems?.length);
   const sentinelRef = useRef(null);
 
   useEffect(() => {
-    console.log("this comes through first");
     fetchInitialFeed();
   }, []);
 

--- a/client/src/components/feed/FeedItem.jsx
+++ b/client/src/components/feed/FeedItem.jsx
@@ -8,7 +8,6 @@ import "./Feed.css";
 function FeedItem({FeedItem}) {
   const [showComments, setShowComments] = useState(false);
   const {watchedId, friend, content, rating, interactions} = FeedItem;
-  console.log("updated", FeedItem);
   const {toggleLike} = useFeed();
 
   const getAction = () => {

--- a/client/src/components/nav/Sidebar.jsx
+++ b/client/src/components/nav/Sidebar.jsx
@@ -20,10 +20,8 @@ const Sidebar = ({activeIcon, onActiveIconChange}) => {
   const [searchValue, setSearchValue] = useState("");
 
   const handleLogout = async () => {
-    console.log("Hello");
     try {
       const result = await userLogout();
-      console.log("what", result);
       if (result.success) {
         setUser(null);
         window.location.replace("/");
@@ -65,7 +63,6 @@ const Sidebar = ({activeIcon, onActiveIconChange}) => {
   };
 
   const renderItems = () => {
-    console.log("actuve icon", activeIcon);
     return items.map((item) => (
       <button
         key={item.id}

--- a/client/src/components/profile/EditProfileModal.jsx
+++ b/client/src/components/profile/EditProfileModal.jsx
@@ -87,7 +87,7 @@ const EditProfileModal = ({
       // Save profile data
       const profileData = {
         bio,
-        isPublic: true,
+        privacyLevel: null,
         profilePicture: imageUrl,
         favoriteGenres,
       };

--- a/client/src/components/profile/SearchResults.jsx
+++ b/client/src/components/profile/SearchResults.jsx
@@ -39,7 +39,6 @@ const SearchResults = () => {
     }
     setIsLoading(true);
     try {
-      console.log("searching for users", query);
       const result = await searchUsersByUsername(query);
       console.log("result", result);
       if (result.success) {
@@ -165,7 +164,9 @@ const SearchResults = () => {
               </div>
             ) : (
               <div className="movie-grid">
-                {mediaResults.map((item) => renderMediaItem(item))}
+                {addFlagsToMovies(mediaResults).map((item) =>
+                  renderMediaItem(item)
+                )}
               </div>
             )}
           </div>

--- a/client/src/context/FeedContext.jsx
+++ b/client/src/context/FeedContext.jsx
@@ -14,7 +14,6 @@ export const FeedProvider = ({children}) => {
   // friend filter states
   const [selectedFriends, setSelectedFriends] = useState(new Set());
   const [showAllFriends, setShowAllFriends] = useState(true);
-  console.log("friends", selectedFriends);
   const fetchInitialFeed = async () => {
     setInitialLoading(true);
     setError(null);

--- a/client/src/context/MovieContext.jsx
+++ b/client/src/context/MovieContext.jsx
@@ -127,8 +127,8 @@ function MovieProvider({children}) {
         const movieData = {
           tmdbId: movieId,
           posterPath: movie.poster_path,
-          title: movie.poster_path,
-          overview: movie.poster_path,
+          title: movie.title,
+          overview: movie.overview,
         };
         await addWantToWatchMovie(movieData);
       }

--- a/client/src/context/ProfileContext.jsx
+++ b/client/src/context/ProfileContext.jsx
@@ -60,7 +60,6 @@ export const ProfileProvider = ({children}) => {
 
   const fetchUserStats = async (userId) => {
     const result = await getUserStats(userId);
-    console.log("omgg", result.stats);
     setUserStats({
       tvShowsWatched: result.stats.TvShowCount,
       moviesWatched: result.stats.movieCount,

--- a/client/src/utils/MediaApiUtils.js
+++ b/client/src/utils/MediaApiUtils.js
@@ -5,9 +5,7 @@ export const getCurrentDate = () => {
 
 export const getDateThreeMonthsLater = () => {
   const date = new Date();
-  console.log("date", date);
   date.setMonth(date.getMonth() + 3);
-  console.log("after ", date.toISOString().split("T")[0]);
   return date.toISOString().split("T")[0];
 };
 

--- a/server/database/UsersUtils.js
+++ b/server/database/UsersUtils.js
@@ -11,7 +11,7 @@ async function searchUserByUsername(searchQuery) {
       p{
       .id,
       .bio,
-      .isPublic,
+      .privacyLevel,
       .profilePicture,
       .favoriteGenres
       } as profile
@@ -28,7 +28,7 @@ async function searchUserByUsername(searchQuery) {
         username: record.get("username"),
         profileId: profile.id,
         bio: profile.bio,
-        isPublic: profile.isPublic,
+        privacyLevel: profile.privacyLevel,
         profilePicture: profile.profilePicture,
         favoriteGenres: profile.favoriteGenres,
       };
@@ -48,7 +48,7 @@ async function getUserProfileByUsername(username) {
       p{
       .id,
       .bio,
-      .isPublic,
+      .privacyLevel,
       .profilePicture,
       .favoriteGenres,
       .createdAt,
@@ -70,7 +70,7 @@ async function getUserProfileByUsername(username) {
       username: record.get("username"),
       id: profile.id,
       bio: profile.bio,
-      isPublic: profile.isPublic,
+      privacyLevel: profile.privacyLevel,
       profilePicture: profile.profilePicture,
       createdAt: profile.createdAt,
       updatedAt: profile.updatedAt,

--- a/server/database/feedUtils.js
+++ b/server/database/feedUtils.js
@@ -6,28 +6,112 @@ async function getFeed(userId, page, limit) {
   try {
     const offset = parseInt(page - 1) * limit;
     const query = `
-  MATCH (currentUser:User {id: $userId})-[:FOLLOWS]->(friend:User)-[w:WATCHED]->(content)
-  WHERE content:Movie OR content:TVShow
-  MATCH (friend)-[:HAS_PROFILE]->(friendProfile:Profile)
+  MATCH (author: User)-[:HAS_PROFILE]->(profile: Profile {privacyLevel: 'public'})
+MATCH (author)-[watched: WATCHED]->(content)
+WHERE (content:Movie OR content:TVShow)
+AND author.id <> $userId
+RETURN watched {
+  .id,
+  .rating,
+  .review,
+  .watchedAt
+} as post,
+author {
+  .id,
+  .username
+} as author,
+profile {
+  .profilePicture,
+  .privacyLevel
+} as profile,
+content {
+  .title,
+  .posterPath,
+  .overview
+} as contentDetails,
+labels(content)[0] as contentType,
+size(coalesce(watched.likedBy,[])) as likesCount,
+size(coalesce(watched.commentTexts, [])) as commentsCount,
+$userId IN coalesce(watched.likedBy, []) as userLiked,
+id(watched) as watchedId,
+'public' as category
 
-  RETURN
-    friend.username AS friendUsername,
-    friend.id AS friendId,
-    friendProfile.profilePicture AS friendProfilePicture,
-    w.rating AS rating,
-    w.review AS review,
-    w.watchedAt AS watchedAt,
-    content.title AS contentTitle,
-    content.posterPath AS contentPoster,
-    content.overview AS contentOverview,
-    labels(content)[0] AS contentType,
-    size(coalesce(w.likedBy,[])) as likesCount,
-    size(coalesce(w.commentTexts, [])) as commentsCount,
-    $userId IN coalesce(w.likedBy, []) as userLiked,
-    id(w) as watchedId
-  ORDER BY w.watchedAt DESC
-  SKIP $offset
-  LIMIT $limit
+UNION
+
+MATCH (me: User {id: $userId})
+MATCH (author: User)-[:HAS_PROFILE]->(profile: Profile {privacyLevel: 'friends_of_friends'})
+MATCH (author)-[watched: WATCHED]->(content)
+WHERE (content:Movie OR content:TVShow)
+AND author.id <> me
+AND (
+  (me)-[:FOLLOWS]->(author)  
+  OR 
+  EXISTS {
+    MATCH (me)-[:FOLLOWS]->(someone:User)-[:FOLLOWS]->(author)
+  }
+)
+RETURN watched {
+  .id,
+  .rating,
+  .review,
+  .watchedAt
+} as post,
+author {
+  .id,
+  .username
+} as author,
+profile {
+  .profilePicture,
+  .privacyLevel
+} as profile,
+content {
+  .title,
+  .posterPath,
+  .overview
+} as contentDetails,
+labels(content)[0] as contentType,
+size(coalesce(watched.likedBy,[])) as likesCount,
+size(coalesce(watched.commentTexts, [])) as commentsCount,
+$userId IN coalesce(watched.likedBy, []) as userLiked,
+id(watched) as watchedId,
+'friends_of_friends' as category
+
+UNION
+
+MATCH (me: User {id: $userId})-[:FOLLOWS]->(author: User)
+MATCH (author)-[:HAS_PROFILE]->(profile: Profile {privacyLevel: 'friends_only'})
+MATCH (author)-[watched: WATCHED]->(content)
+WHERE (content: Movie OR content: TVShow)
+AND author <> me
+RETURN watched {
+  .id,
+  .rating,
+  .review,
+  .watchedAt
+} as post,
+author {
+  .id,
+  .username
+} as author,
+profile {
+  .profilePicture,
+  .privacyLevel
+} as profile,
+content {
+  .title,
+  .posterPath,
+  .overview
+} as contentDetails,
+labels(content)[0] as contentType,
+size(coalesce(watched.likedBy,[])) as likesCount,
+size(coalesce(watched.commentTexts, [])) as commentsCount,
+$userId IN coalesce(watched.likedBy, []) as userLiked,
+id(watched) as watchedId,
+'friends_only' as category
+
+ORDER BY post.createdAt DESC
+SKIP $offset
+LIMIT $limit
 `;
     const params = {
       userId,
@@ -40,20 +124,21 @@ async function getFeed(userId, page, limit) {
     const feedItems = result.records.map((record) => ({
       watchedId: record.get("watchedId").toString(),
       friend: {
-        id: record.get("friendId"),
-        username: record.get("friendUsername"),
-        profilePicture: record.get("friendProfilePicture"),
+        id: record.get("author").id,
+        username: record.get("author").username,
+        profilePicture: record.get("profile").profilePicture,
+        privacyLevel: record.get("profile").privacyLevel,
       },
       content: {
-        title: record.get("contentTitle"),
-        posterPath: record.get("contentPoster"),
-        overview: record.get("contentOverview"),
+        title: record.get("contentDetails").title,
+        posterPath: record.get("contentDetails").posterPath,
+        overview: record.get("contentDetails").overview,
         type: record.get("contentType"),
       },
       rating: {
-        rating: record.get("rating"),
-        review: record.get("review"),
-        watchedAt: record.get("watchedAt").toString(),
+        rating: record.get("post").rating,
+        review: record.get("post").review,
+        watchedAt: record.get("post").watchedAt.toString(),
       },
       interactions: {
         likesCount: record.get("likesCount").toNumber(),


### PR DESCRIPTION
## Description

<what this pull request is doing>
This pull requests includes: 

Iterations of follow request feature. Previously profile visibility was managed with a binary isPublic: true/false. Visibility of the profile also did not affect feed activity because feed only queried for posts of friends (those you follow). Now friend request are managed based on 3 categories and these affect the visibility of the profile/posts in the feed. Here are the categories:

1. Friends Only

- Only users who directly follow the profile owner (incoming edge in the directed follower graph) can see the profile and posts. In other words, user V is a friend of user U if there is a directed edge V → U.
Only friends qualify to see posts or profile.

2. Friends of Friends

- Visibility extends to direct friends and users connected via a two-step directed follower chain.

- Logic: If A follows B and B follows C, then A is a friend of a friend of C (path A → B → C).

Only users with such a directed path to the profile owner qualify to see posts from this user/profile.

3. Profile and posts are visible to all users, regardless of follower relationships.

Other changes: 

- Edited the cypher to query for the feed items in terms of visibility.

- I also modified my previous implementation of recommend a friend to be a Mutual Friend-Based recommendation instead. Before I used to query for friends of friends, but I realized this is not appropriate to foster connections since a follow relationship does not necessarily entail "a personal relationship", which is that of a friends.
- Cancel Request Button along with endpoints and helper functions. Users can now cancel a outgoing request. 

<what will be done in later PRs and not included here>
In future pull requests:

- I will refactor code.

## Milestones
User story: As a TV show fanatic, I want to be able to connect with other people outside of people who I add as my friends 
User story: 

## Test Plan
I tested using three fictional users 

I tested using three fictional users:
**keys:** -> = follows

- First phase: Al has a public profile and follows no one. She posted a movie review, which appeared on everyone's profile.
Graph: (MYSELF       Al      Bob)

- Second phase: I follow Al. Al follows Bob. Bob sets his privacy settings to "friends of friends." Bob posts a movie review, and Ana is able to see this post. However, when I post a movie review, Bob is not able to see it because my profile is private.
Graph: (MYSELF -> Al -> Bob)

- Second phase: I also made Al follow me, and Bob follow Al to test recommendations. As expected, Bob was recommended to Ana, and Ana was recommended to Bob.
Graph:  ( MYSELF <-> Al <-> Bob)

- Third phase: Bob changes his profile to private. I am now unable to see his posts.
Graph: (MYSELF -> Al -> Bob)
